### PR TITLE
Resolve breaking issues from upgrade + Added chart features

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/series-vertical.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/series-vertical.component.ts
@@ -128,11 +128,11 @@ export class SeriesVerticalComponent implements OnChanges {
       total = this.series.map(d => d.value).reduce((sum, d) => sum + d, 0);
     }
 
-    let topNameOfGroup: string | undefined;
+    let topNameOfGroup: StringOrNumberOrDate;
 
     for (let i = this.series.length - 1; i >= 0; i--) {
       if (this.series[i].value !== 0) {
-        topNameOfGroup = this.series[i].name;
+          topNameOfGroup = this.series[i].name;
         break;
       }
     }

--- a/projects/swimlane/ngx-charts/src/lib/common/area.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/area.component.ts
@@ -12,6 +12,7 @@ import { Gradient } from './types/gradient.interface';
       <svg:g
         ngx-charts-svg-linear-gradient
         [orientation]="barOrientation.Vertical"
+        [gradientDirection]="gradientDirection"
         [name]="gradientId"
         [stops]="gradientStops"
       />
@@ -31,6 +32,7 @@ export class AreaComponent implements OnChanges {
   @Input() gradient: boolean = false;
   @Input() stops: Gradient[];
   @Input() animations: boolean = true;
+  @Input() gradientDirection: string;
 
   @Output() select = new EventEmitter();
 
@@ -50,7 +52,7 @@ export class AreaComponent implements OnChanges {
 
   ngOnChanges(): void {
     this.update();
-
+        
     if (!this.animationsLoaded) {
       this.loadAnimation();
       this.animationsLoaded = true;

--- a/projects/swimlane/ngx-charts/src/lib/common/base-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/base-chart.component.ts
@@ -34,6 +34,7 @@ export class BaseChartComponent implements OnChanges, AfterViewInit, OnDestroy {
   @Input() schemeType: ScaleType = ScaleType.Ordinal;
   @Input() customColors: any;
   @Input() animations: boolean = true;
+  @Input() chartContainer: ElementRef;
 
   @Output() select = new EventEmitter();
 
@@ -113,11 +114,11 @@ export class BaseChartComponent implements OnChanges, AfterViewInit, OnDestroy {
   getContainerDims(): ViewDimensions {
     let width;
     let height;
-    const hostElem = this.chartElement.nativeElement;
+    const hostElem = this.chartContainer ?? this.chartElement?.nativeElement;
 
-    if (isPlatformBrowser(this.platformId) && hostElem.parentNode !== null) {
+    if (hostElem && hostElem.parentNode !== null) {
       // Get the container dimensions
-      const dims = hostElem.parentNode.getBoundingClientRect();
+      const dims = this.chartContainer ? hostElem.getBoundingClientRect() : hostElem.parentNode.getBoundingClientRect();
       width = dims.width;
       height = dims.height;
     }

--- a/projects/swimlane/ngx-charts/src/lib/common/circle-series.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/circle-series.component.ts
@@ -55,7 +55,7 @@ export interface Circle {
         />
       </defs>
       <svg:rect
-        *ngIf="barVisible && type === 'standard'"
+        *ngIf="!tooltipBarDisabled && barVisible && type === 'standard'"
         [@animationState]="'active'"
         [attr.x]="circle.cx - circle.radius"
         [attr.y]="circle.cy"
@@ -109,6 +109,7 @@ export class CircleSeriesComponent implements OnChanges, OnInit {
   @Input() scaleType: ScaleType;
   @Input() visibleValue: boolean;
   @Input() activeEntries: any[];
+  @Input() tooltipBarDisabled: boolean = false;
   @Input() tooltipDisabled: boolean = false;
   @Input() tooltipTemplate: TemplateRef<any>;
 

--- a/projects/swimlane/ngx-charts/src/lib/common/svg-linear-gradient.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/svg-linear-gradient.component.ts
@@ -20,6 +20,7 @@ export class SvgLinearGradientComponent implements OnChanges {
   @Input() orientation = BarOrientation.Vertical;
   @Input() name: string;
   @Input() stops: Gradient[];
+  @Input() gradientDirection: string;
 
   x1: string;
   x2: string;
@@ -31,11 +32,28 @@ export class SvgLinearGradientComponent implements OnChanges {
     this.x2 = '0%';
     this.y1 = '0%';
     this.y2 = '0%';
-
+        
     if (this.orientation === BarOrientation.Horizontal) {
       this.x2 = '100%';
     } else if (this.orientation === BarOrientation.Vertical) {
-      this.y1 = '100%';
+      switch (this.gradientDirection) {
+        case 'down':
+          this.y2 = '0%';
+          this.y1 = '100%';
+          break;
+        case 'up':
+          this.y2 = '100%';
+          this.y1 = '0%';
+          break;
+        case 'none':
+          this.y2 = '0%';
+          this.y1 = '0%';
+          break;
+        default:
+          this.y2 = '0%';
+          this.y1 = '100%';
+          break;
+      }
     }
   }
 }

--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
@@ -91,6 +91,8 @@ import { ViewDimensions } from '../common/types/view-dimension.interface';
               [rangeFillOpacity]="rangeFillOpacity"
               [hasRange]="hasRange"
               [animations]="animations"
+              [gradient]="gradient"
+              [trueZero]="trueZero"
             />
           </svg:g>
 
@@ -118,6 +120,7 @@ import { ViewDimensions } from '../common/types/view-dimension.interface';
                 [scaleType]="scaleType"
                 [visibleValue]="hoveredVertical"
                 [activeEntries]="activeEntries"
+                [tooltipBarDisabled]="tooltipBarDisabled"
                 [tooltipDisabled]="tooltipDisabled"
                 [tooltipTemplate]="tooltipTemplate"
                 (select)="onClick($event)"
@@ -152,6 +155,8 @@ import { ViewDimensions } from '../common/types/view-dimension.interface';
             [curve]="curve"
             [hasRange]="hasRange"
             [animations]="animations"
+            [gradient]="gradient"
+            [trueZero]="trueZero"
           />
         </svg:g>
       </svg:g>
@@ -204,7 +209,9 @@ export class LineChartComponent extends BaseChartComponent {
   @Input() xAxisTicks: any[];
   @Input() yAxisTicks: any[];
   @Input() roundDomains: boolean = false;
+  @Input() tooltipBarDisabled: boolean = false;
   @Input() tooltipDisabled: boolean = false;
+  @Input() trueZero: boolean;
   @Input() showRefLines: boolean = false;
   @Input() referenceLines: any;
   @Input() showRefLabels: boolean = true;
@@ -249,7 +256,7 @@ export class LineChartComponent extends BaseChartComponent {
 
   update(): void {
     super.update();
-
+    
     this.dims = calculateViewDimensions({
       width: this.width,
       height: this.height,

--- a/projects/swimlane/ngx-charts/src/lib/models/chart-data.model.ts
+++ b/projects/swimlane/ngx-charts/src/lib/models/chart-data.model.ts
@@ -16,6 +16,7 @@ export interface SingleSeries extends Array<DataItem> {}
 export interface Series {
   name: StringOrNumberOrDate;
   series: DataItem[];
+  extra?: any;
 }
 
 export interface MultiSeries extends Array<Series> {}

--- a/projects/swimlane/ngx-charts/src/lib/utils/visibility-observer.ts
+++ b/projects/swimlane/ngx-charts/src/lib/utils/visibility-observer.ts
@@ -28,7 +28,7 @@ export class VisibilityObserver {
     });
   }
 
-  runCheck(): void {
+  runCheck(): void {    
     const check = () => {
       if (!this.element) {
         return;
@@ -42,13 +42,13 @@ export class VisibilityObserver {
         this.onVisibilityChange();
       } else {
         clearTimeout(this.timeout);
-        this.zone.runOutsideAngular(() => {
+        this.zone?.runOutsideAngular(() => {
           this.timeout = setTimeout(() => check(), 100);
         });
       }
     };
 
-    this.zone.runOutsideAngular(() => {
+    this.zone?.runOutsideAngular(() => {
       this.timeout = setTimeout(() => check());
     });
   }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -301,6 +301,7 @@
         [gradient]="gradient"
         [tooltipDisabled]="tooltipDisabled"
         [tooltipText]="pieTooltipText"
+        [margins]="margins"
         (dblclick)="dblclick($event)"
         (select)="select($event)"
         (activate)="activate($event)"
@@ -365,9 +366,11 @@
         [curve]="curve"
         [rangeFillOpacity]="rangeFillOpacity"
         [roundDomains]="roundDomains"
+        [tooltipBarDisabled]="tooltipBarDisabled"
         [tooltipDisabled]="tooltipDisabled"
         [trimXAxisTicks]="trimXAxisTicks"
         [trimYAxisTicks]="trimYAxisTicks"
+        [trueZero]="trueZero"
         [rotateXAxisTicks]="rotateXAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
@@ -998,6 +1001,8 @@
         [results]="sparklineData"
         [animations]="animations"
         [curve]="curve"
+        [gradient]="gradient"
+        [trueZero]="trueZero"
       >
       </ngx-charts-sparkline>
       <ngx-charts-timeline-filter-bar-chart

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -79,16 +79,19 @@ export class AppComponent implements OnInit {
   width: number = 700;
   height: number = 300;
   fitContainer: boolean = false;
-
+  margins: [number, number, number, number];
+  
   // options
   showXAxis = true;
   showYAxis = true;
-  gradient = false;
+  gradient = true;
   showLegend = true;
   legendTitle = 'Legend';
   legendPosition = LegendPosition.Right;
   showXAxisLabel = true;
+  tooltipBarDisabled = true;
   tooltipDisabled = false;
+  trueZero = true;
   showText = true;
   xAxisLabel = 'Country';
   showYAxisLabel = true;
@@ -474,7 +477,7 @@ export class AppComponent implements OnInit {
 
     this.dateDataWithRange = generateData(2, true);
 
-    if (this.chart.inputFormat === 'calendarData') this.calendarData = this.getCalendarData();
+    if (this.chart.inputFormat === 'calendarData') this.calendarData = this.getCalendarData();    
   }
 
   applyDimensions() {
@@ -706,7 +709,7 @@ export class AppComponent implements OnInit {
         value: this.mathFunction(t)
       };
     });
-
+    
     return [
       {
         name: this.mathText,

--- a/src/app/custom-charts/sparkline/sparkline.component.ts
+++ b/src/app/custom-charts/sparkline/sparkline.component.ts
@@ -28,6 +28,8 @@ import {
               [scaleType]="scaleType"
               [curve]="curve"
               [animations]="animations"
+              [gradient]="gradient"
+              [trueZero]="trueZero"
             />
           </svg:g>
         </svg:g>
@@ -44,6 +46,8 @@ export class SparklineComponent extends BaseChartComponent {
   @Input() schemeType: ScaleType = ScaleType.Linear;
   @Input() valueDomain: number[];
   @Input() animations: boolean = true;
+  @Input() gradient: boolean;
+  @Input() trueZero: boolean;
 
   dims: ViewDimensions;
   xSet: any;
@@ -59,7 +63,7 @@ export class SparklineComponent extends BaseChartComponent {
 
   update(): void {
     super.update();
-
+   
     this.dims = calculateViewDimensions({
       width: this.width,
       height: this.height,


### PR DESCRIPTION
This PR addresses several issues encountered during okendo ngx-charts upgrade process and also adds various features and options to better customise the charts.

#### Upgrade issues:

- `topNameOfGroup` type error
- `chartElement` is undefined, hence dimensions could not be set to fit parent size. Actioned `base-chart` component to accept `chartContainer` ElementRef, which will be used instead of `chartElement` where appropriate.
- error from VisibilityObserver (non-breaking), as `zone` was undefined

#### Added features:

- `tooltipBarDisabled` - This option will allow us to disable the tool tip bar on data point hover (see screenshots for reference)
- `trueZero` - When set to `true`, the gradient effect will flow towards 0, as opposed to the bottom of the chart.
- `gradientDirection ` - This can be included as part of `extra` data which gets passed within the chart data, it allows us to control the flow of the gradient fade effect per chart line.
- `gradient` can now be passed as an input from the initial line chart reference, to either enable or disable the gradient completely. This setting was originally inaccessible and would have no effect (contrary to documentation). https://github.com/swimlane/ngx-charts/issues/1224
- `margins` can now be passed as an input from pie chart reference. This gives us direct access to margin settings in the pie chart.

#### Screenshots

With customisations:
![Screen Shot 2021-12-13 at 4 29 16 pm](https://user-images.githubusercontent.com/95736976/145757446-47bd2c0f-ae34-47c2-b064-1bbc0d8cc6cc.png)

Without customisations:
![Screen Shot 2021-12-13 at 4 52 06 pm](https://user-images.githubusercontent.com/95736976/145759611-70dbba49-4329-4b5a-b3e0-f6b99399e859.png)


Related PR
https://bitbucket.org/okendo/reviews-admin/pull-requests/1089/ngx-charts-upgrade-and-customisations
