### PR TITLE
Add customisations to 14.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Fork from [https://github.com/swimlane/ngx-charts]
 
 ## Add-on Features
 
+## 14.0.1
+- `tooltipBarDisabled` Option to disable the tool tip bar on data point hover
+- `trueZero` Gradient effect flow towards 0
+- `gradientDirection` Sets the flow of the gradient fade effect per chart line
+- `gradient` Can be passed as an input from the initial line chart reference. Enabled by default.
+- `margins` Can be passed as an input from pie chart reference
+
 ### Max width of each bar on bar chart
 
 Use `barMaxWidth` attribute with default value 100px

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 14.0.1
+- `tooltipBarDisabled`: Option to disable the tool tip bar on data point hover
+- `trueZero`: Gradient effect flow towards 0
+- `gradientDirection`: Sets the flow of the gradient fade effect per chart line
+- `gradient`: Can now be passed as an input from the initial line chart reference to toggle the gradient. Enabled by default.
+- `margins`: Can now be passed as an input from pie chart reference
+
+
 ## 14.0.0
 
 - Chore: explicitly only suppot ng9

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-charts",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-charts",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/swimlane/ngx-charts/package.json
+++ b/projects/swimlane/ngx-charts/package.json
@@ -1,6 +1,6 @@
 {
 "name": "@okendo/ngx-charts",
-"version": "14.0.0",
+"version": "14.0.1",
   "description": "Declarative Charting Framework for Angular",
   "repository": {
     "type": "git",

--- a/projects/swimlane/ngx-charts/src/lib/common/area.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/area.component.ts
@@ -15,7 +15,7 @@ import { id } from '../utils/id';
   selector: 'g[ngx-charts-area]',
   template: `
     <svg:defs *ngIf="gradient">
-      <svg:g ngx-charts-svg-linear-gradient orientation="vertical" [name]="gradientId" [stops]="gradientStops" />
+      <svg:g ngx-charts-svg-linear-gradient orientation="vertical" [gradientDirection]="gradientDirection" [name]="gradientId" [stops]="gradientStops" />
     </svg:defs>
     <svg:path class="area" [attr.d]="areaPath" [attr.fill]="gradient ? gradientFill : fill" [style.opacity]="opacity" />
   `,
@@ -33,7 +33,8 @@ export class AreaComponent implements OnChanges {
   @Input() gradient: boolean = false;
   @Input() stops: any[];
   @Input() animations: boolean = true;
-
+  @Input() gradientDirection: string;
+  
   @Output() select = new EventEmitter();
 
   element: HTMLElement;

--- a/projects/swimlane/ngx-charts/src/lib/common/circle-series.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/circle-series.component.ts
@@ -27,7 +27,7 @@ import { ColorHelper } from '../common/color.helper';
         />
       </defs>
       <svg:rect
-        *ngIf="barVisible && type === 'standard'"
+        *ngIf="!tooltipBarDisabled && barVisible && type === 'standard'"
         [@animationState]="'active'"
         [attr.x]="circle.cx - circle.radius"
         [attr.y]="circle.cy"
@@ -81,6 +81,7 @@ export class CircleSeriesComponent implements OnChanges, OnInit {
   @Input() scaleType;
   @Input() visibleValue;
   @Input() activeEntries: any[];
+  @Input() tooltipBarDisabled: boolean = false;
   @Input() tooltipDisabled: boolean = false;
   @Input() tooltipTemplate: TemplateRef<any>;
 

--- a/projects/swimlane/ngx-charts/src/lib/common/svg-linear-gradient.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/svg-linear-gradient.component.ts
@@ -18,6 +18,7 @@ export class SvgLinearGradientComponent implements OnChanges {
   @Input() orientation = 'vertical';
   @Input() name;
   @Input() stops: any[];
+  @Input() gradientDirection: string;
 
   x1: any;
   x2: any;
@@ -33,7 +34,24 @@ export class SvgLinearGradientComponent implements OnChanges {
     if (this.orientation === 'horizontal') {
       this.x2 = '100%';
     } else if (this.orientation === 'vertical') {
-      this.y1 = '100%';
+      switch (this.gradientDirection) {
+        case 'down':
+          this.y2 = '0%';
+          this.y1 = '100%';
+          break;
+        case 'up':
+          this.y2 = '100%';
+          this.y1 = '0%';
+          break;
+        case 'none':
+          this.y2 = '0%';
+          this.y1 = '0%';
+          break;
+        default:
+          this.y2 = '0%';
+          this.y1 = '100%';
+          break;
+      }
     }
   }
 }

--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
@@ -188,7 +188,7 @@ export class LineChartComponent extends BaseChartComponent {
   @Input() yAxisLabel;
   @Input() autoScale;
   @Input() timeline;
-  @Input() gradient: boolean;
+  @Input() gradient: boolean = true;
   @Input() showGridLines: boolean = true;
   @Input() curve: any = curveLinear;
   @Input() activeEntries: any[] = [];

--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
@@ -88,6 +88,8 @@ import { getUniqueXDomainValues, getScaleType } from '../common/domain.helper';
               [rangeFillOpacity]="rangeFillOpacity"
               [hasRange]="hasRange"
               [animations]="animations"
+              [gradient]="gradient"
+              [trueZero]="trueZero"
             />
           </svg:g>
 
@@ -115,6 +117,7 @@ import { getUniqueXDomainValues, getScaleType } from '../common/domain.helper';
                 [scaleType]="scaleType"
                 [visibleValue]="hoveredVertical"
                 [activeEntries]="activeEntries"
+                [tooltipBarDisabled]="tooltipBarDisabled"
                 [tooltipDisabled]="tooltipDisabled"
                 [tooltipTemplate]="tooltipTemplate"
                 (select)="onClick($event)"
@@ -201,7 +204,9 @@ export class LineChartComponent extends BaseChartComponent {
   @Input() xAxisTicks: any[];
   @Input() yAxisTicks: any[];
   @Input() roundDomains: boolean = false;
+  @Input() tooltipBarDisabled: boolean = false;
   @Input() tooltipDisabled: boolean = false;
+  @Input() trueZero: boolean;
   @Input() showRefLines: boolean = false;
   @Input() referenceLines: any;
   @Input() showRefLabels: boolean = true;

--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-series.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-series.component.ts
@@ -25,7 +25,8 @@ import { sortLinear, sortByTime, sortByDomain } from '../utils/sort';
         [fill]="hasGradient ? gradientUrl : colors.getColor(data.name)"
         [opacity]="0.25"
         [startOpacity]="0"
-        [gradient]="true"
+        [gradient]="gradient"
+        [gradientDirection]="gradientDirection"
         [stops]="areaGradientStops"
         [class.active]="isActive(data)"
         [class.inactive]="isInactive(data)"
@@ -68,6 +69,8 @@ export class LineSeriesComponent implements OnChanges {
   @Input() rangeFillOpacity: number;
   @Input() hasRange: boolean;
   @Input() animations: boolean = true;
+  @Input() gradient: boolean;
+  @Input() trueZero: boolean;
 
   path: string;
   outerPath: string;
@@ -78,6 +81,7 @@ export class LineSeriesComponent implements OnChanges {
   gradientStops: any[];
   areaGradientStops: any[];
   stroke: any;
+  gradientDirection: string;
 
   ngOnChanges(changes: SimpleChanges): void {
     this.update();
@@ -157,7 +161,7 @@ export class LineSeriesComponent implements OnChanges {
 
     return area<any>()
       .x(xProperty)
-      .y0(() => this.yScale.range()[0])
+      .y0(() => this.trueZero ? this.yScale(0) : this.yScale.range()[0])
       .y1(d => this.yScale(d.value))
       .curve(this.curve);
   }
@@ -175,6 +179,8 @@ export class LineSeriesComponent implements OnChanges {
   }
 
   updateGradients() {
+    this.gradientDirection = this.data.extra?.gradientDirection;
+    
     if (this.colors.scaleType === 'linear') {
       this.hasGradient = true;
       this.gradientId = 'grad' + id().toString();

--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-series.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-series.component.ts
@@ -69,7 +69,7 @@ export class LineSeriesComponent implements OnChanges {
   @Input() rangeFillOpacity: number;
   @Input() hasRange: boolean;
   @Input() animations: boolean = true;
-  @Input() gradient: boolean;
+  @Input() gradient: boolean = true;
   @Input() trueZero: boolean;
 
   path: string;

--- a/projects/swimlane/ngx-charts/src/lib/models/chart-data.model.ts
+++ b/projects/swimlane/ngx-charts/src/lib/models/chart-data.model.ts
@@ -12,6 +12,9 @@ export interface SingleSeries extends Array<DataItem> {}
 export interface Series {
   name: string | number | Date;
   series: DataItem[];
+  extra?: {
+    gradientDirection?: string;
+  };
 }
 
 export interface MultiSeries extends Array<Series> {}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -310,6 +310,7 @@
         [gradient]="gradient"
         [tooltipDisabled]="tooltipDisabled"
         [tooltipText]="pieTooltipText"
+        [margins]="margins"
         (dblclick)="dblclick($event)"
         (select)="select($event)"
         (activate)="activate($event)"
@@ -377,9 +378,11 @@
         [curve]="curve"
         [rangeFillOpacity]="rangeFillOpacity"
         [roundDomains]="roundDomains"
+        [tooltipBarDisabled]="tooltipBarDisabled"
         [tooltipDisabled]="tooltipDisabled"
         [trimXAxisTicks]="trimXAxisTicks"
         [trimYAxisTicks]="trimYAxisTicks"
+        [trueZero]="trueZero"
         [rotateXAxisTicks]="rotateXAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
         [maxYAxisTickLength]="maxYAxisTickLength"
@@ -1004,6 +1007,8 @@
         [results]="sparklineData"
         [animations]="animations"
         [curve]="curve"
+        [gradient]="gradient"
+        [trueZero]="trueZero"
       >
       </ngx-charts-sparkline>
       <ngx-charts-timeline-filter-bar-chart

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -69,7 +69,8 @@ export class AppComponent implements OnInit {
   width: number = 700;
   height: number = 300;
   fitContainer: boolean = false;
-
+  margins: [number, number, number, number];
+  
   // options
   showXAxis = true;
   showYAxis = true;
@@ -78,7 +79,9 @@ export class AppComponent implements OnInit {
   legendTitle = 'Legend';
   legendPosition = 'right';
   showXAxisLabel = true;
+  tooltipBarDisabled = false;
   tooltipDisabled = false;
+  trueZero = false;
   showText = true;
   xAxisLabel = 'Country';
   showYAxisLabel = true;

--- a/src/app/custom-charts/sparkline/sparkline.component.ts
+++ b/src/app/custom-charts/sparkline/sparkline.component.ts
@@ -45,7 +45,7 @@ export class SparklineComponent extends BaseChartComponent {
   @Input() schemeType: string = 'linear';
   @Input() valueDomain: number[];
   @Input() animations: boolean = true;
-  @Input() gradient: boolean;
+  @Input() gradient: boolean = true;
   @Input() trueZero: boolean;
   
   dims: ViewDimensions;

--- a/src/app/custom-charts/sparkline/sparkline.component.ts
+++ b/src/app/custom-charts/sparkline/sparkline.component.ts
@@ -27,6 +27,8 @@ import {
               [scaleType]="scaleType"
               [curve]="curve"
               [animations]="animations"
+              [gradient]="gradient"
+              [trueZero]="trueZero"
             />
           </svg:g>
         </svg:g>
@@ -43,7 +45,9 @@ export class SparklineComponent extends BaseChartComponent {
   @Input() schemeType: string = 'linear';
   @Input() valueDomain: number[];
   @Input() animations: boolean = true;
-
+  @Input() gradient: boolean;
+  @Input() trueZero: boolean;
+  
   dims: ViewDimensions;
   xSet: any;
   xDomain: any;


### PR DESCRIPTION
#### Added features:

- `tooltipBarDisabled` - This option will allow us to disable the tool tip bar on data point hover (see screenshots for reference)
- `trueZero` - When set to `true`, the gradient effect will flow towards 0, as opposed to the bottom of the chart.
- `gradientDirection ` - This can be included as part of `extra` data which gets passed within the chart data, it allows us to control the flow of the gradient fade effect per chart line.
- `gradient` can now be passed as an input from the initial line chart reference, to either enable or disable the gradient completely. This setting was originally inaccessible and would have no effect (contrary to documentation). https://github.com/swimlane/ngx-charts/issues/1224
- `margins` can now be passed as an input from pie chart reference. This gives us direct access to margin settings in the pie chart.

#### Screenshots

With customisations:
![Screen Shot 2021-12-13 at 4 29 16 pm](https://user-images.githubusercontent.com/95736976/145757446-47bd2c0f-ae34-47c2-b064-1bbc0d8cc6cc.png)

Without customisations:
![Screen Shot 2021-12-13 at 4 52 06 pm](https://user-images.githubusercontent.com/95736976/145759611-70dbba49-4329-4b5a-b3e0-f6b99399e859.png)


Related PR
https://github.com/okendo/okendo-ngx-charts/pull/3