### PR TITLE
Rounding edges only when roundEdges prop is passed and bar values are positive.

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-stacked.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-stacked.component.ts
@@ -79,6 +79,7 @@ import { BaseChartComponent } from '../common/base-chart.component';
             [showDataLabel]="showDataLabel"
             [dataLabelFormatting]="dataLabelFormatting"
             [seriesName]="group.name"
+            [roundEdges]="roundEdges"
             [animations]="animations"
             [chartLeftOffset]="chartLeftOffset"
             [noBarWhenZero]="noBarWhenZero"
@@ -131,6 +132,7 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
   @Input() xAxisTicks: any[];
   @Input() yAxisTicks: any[];
   @Input() barPadding = 8;
+  @Input() roundEdges: boolean = true;
   @Input() roundDomains: boolean = false;
   @Input() yScaleMax: number;
   @Input() showDataLabel: boolean = false;

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/series-vertical.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/series-vertical.component.ts
@@ -124,14 +124,28 @@ export class SeriesVerticalComponent implements OnChanges {
       total = this.series.map(d => d.value).reduce((sum, d) => sum + d, 0);
     }
 
+    let topNameOfGroup: string | undefined;
+
+    for (let i = this.series.length - 1; i >= 0; i--) {
+      if (this.series[i].value !== 0) {
+        topNameOfGroup = this.series[i].name;
+        break;
+      }
+    }
+
     this.bars = this.series.map((d, index) => {
       let value = d.value;
       const label = this.getLabel(d);
       const formattedLabel = formatLabel(label);
-      const roundEdges = this.roundEdges;
-      const isLastBar = index === this.series.length - 1;
-
       d0Type = value > 0 ? D0Types.positive : D0Types.negative;
+      let roundEdges;
+
+      if (this.type === 'stacked' && (d.name !== topNameOfGroup || d0Type === D0Types.negative)) {
+        roundEdges = false;
+      }
+      else {
+        roundEdges = this.roundEdges;
+      }
 
       const bar: any = {
         value,
@@ -164,10 +178,6 @@ export class SeriesVerticalComponent implements OnChanges {
         bar.y = this.yScale(offset1);
         bar.offset0 = offset0;
         bar.offset1 = offset1;
-
-        if (!isLastBar) {
-          bar.roundEdges = false;
-        }
       } else if (this.type === 'normalized') {
         let offset0 = d0[d0Type];
         let offset1 = offset0 + value;

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/series-vertical.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/series-vertical.component.ts
@@ -124,27 +124,12 @@ export class SeriesVerticalComponent implements OnChanges {
       total = this.series.map(d => d.value).reduce((sum, d) => sum + d, 0);
     }
 
-    let topNameOfGroup: string | undefined;
-
-    for (let i = this.series.length - 1; i >= 0; i--) {
-      if (this.series[i].value !== 0) {
-        topNameOfGroup = this.series[i].name;
-        break;
-      }
-    }
-
     this.bars = this.series.map((d, index) => {
       let value = d.value;
       const label = this.getLabel(d);
       const formattedLabel = formatLabel(label);
-      let roundEdges;
-
-      if ((this.type === 'stacked' && d.name === topNameOfGroup)) {
-        roundEdges = true;
-      }
-      else {
-        roundEdges = this.roundEdges;
-      }
+      const roundEdges = this.roundEdges;
+      const isLastBar = index === this.series.length - 1;
 
       d0Type = value > 0 ? D0Types.positive : D0Types.negative;
 
@@ -179,6 +164,10 @@ export class SeriesVerticalComponent implements OnChanges {
         bar.y = this.yScale(offset1);
         bar.offset0 = offset0;
         bar.offset1 = offset1;
+
+        if (!isLastBar) {
+          bar.roundEdges = false;
+        }
       } else if (this.type === 'normalized') {
         let offset0 = d0[d0Type];
         let offset1 = offset0 + value;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -175,6 +175,7 @@
         [showGridLines]="showGridLines"
         [barPadding]="barPadding"
         [roundDomains]="roundDomains"
+        [roundEdges]="roundEdges"
         [yScaleMax]="yScaleMax"
         [noBarWhenZero]="noBarWhenZero"
         [showDataLabel]="showDataLabel"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1056,6 +1056,7 @@
       [showGridLines]="showGridLines"
       [barPadding]="barPadding"
       [roundDomains]="roundDomains"
+      [roundEdges]="roundEdges"
       [noBarWhenZero]="noBarWhenZero"
       [yScaleMax]="yScaleMax"
       [showDataLabel]="showDataLabel"

--- a/src/app/chartTypes.ts
+++ b/src/app/chartTypes.ts
@@ -166,6 +166,7 @@ const chartGroups = [
           'yAxisLabel',
           'showGridLines',
           'roundDomains',
+          'roundEdges',
           'tooltipDisabled',
           'yScaleMax',
           'showDataLabel',


### PR DESCRIPTION
This change is to modify a previous [commit](https://github.com/okendo/okendo-ngx-charts/commit/948c2df5f4ce42bd40eab9919f471524f7949ba3) that causes a bug with the vertical stacked bar graph when rounding bar edges for bars that have negative values.

This change also introduces the `roundEdges` for the vertical stack bar graph which allows the rounding of edges for positive bars only to maintain the existing functionality.

**This is an example of the bug:**

![image](https://github.com/okendo/okendo-ngx-charts/assets/96367999/fc9ecd2e-1c1c-460d-968b-d5b42e310e74)

**This is an example of the fix with `roundEdges` enabled:**

<img width="770" alt="image" src="https://github.com/okendo/okendo-ngx-charts/assets/96367999/a30f56ce-28ca-48aa-925e-6e9f3a56be0c">

**This is an example of the fix with `roundEdges` disabled:**

<img width="776" alt="image" src="https://github.com/okendo/okendo-ngx-charts/assets/96367999/2cd52704-913a-4ffa-9938-303cc2eb2116">

**Sentiment Bar Graph with rounding working as previous:**

<img width="1857" alt="image" src="https://github.com/okendo/okendo-ngx-charts/assets/96367999/bba5783b-4d95-4ef6-add3-f42b7d943cef">
